### PR TITLE
Adding functions mentioned in #6

### DIFF
--- a/p3a_symmetric3x3.hpp
+++ b/p3a_symmetric3x3.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef P3A_DEBUG
+#include <stdexcept>
+#endif
 #include "p3a_macros.hpp"
 #include "p3a_scaled_identity3x3.hpp"
 #include "p3a_diagonal3x3.hpp"
@@ -268,10 +271,10 @@ auto operator*(symmetric3x3<A> const& a, symmetric3x3<B> const& b)
 
 template <class T>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-symmetric3x3<T> isotropic_part(symmetric3x3<T> const& a)
+scaled_identity3x3<T> isotropic_part(symmetric3x3<T> const& a)
 {
   auto const d = trace(a) / T(3.);
-  return symmetric3x3<T>(d, T(0.0), T(0.0), d, T(0.0), d);
+  return scaled_identity3x3<T>(d);
 }
 
 template <class T>
@@ -313,10 +316,10 @@ auto inverse(symmetric3x3<T> const& a)
 {
   auto const det = determinant(a);
   T constexpr epsilon = std::numeric_limits<T>::epsilon();
+#ifdef P3A_DEBUG
   if (std::abs(det) <= epsilon)
-  {
     throw std::logic_error("non-invertible matrix");
-  }
+#endif
   auto const xx = +(a.yy() * a.zz() - a.yz() * a.yz());
   auto const xy = -(a.xy() * a.zz() - a.yz() * a.xz());
   auto const xz = +(a.xy() * a.yz() - a.yy() * a.xz());

--- a/p3a_symmetric3x3.hpp
+++ b/p3a_symmetric3x3.hpp
@@ -315,8 +315,8 @@ template <class T>
 auto inverse(symmetric3x3<T> const& a)
 {
   auto const det = determinant(a);
-  T constexpr epsilon = std::numeric_limits<T>::epsilon();
 #ifdef P3A_DEBUG
+  T constexpr epsilon = std::numeric_limits<T>::epsilon();
   if (std::abs(det) <= epsilon)
     throw std::logic_error("non-invertible matrix");
 #endif

--- a/p3a_symmetric3x3.hpp
+++ b/p3a_symmetric3x3.hpp
@@ -3,6 +3,7 @@
 #include "p3a_macros.hpp"
 #include "p3a_scaled_identity3x3.hpp"
 #include "p3a_diagonal3x3.hpp"
+#include "p3a_vector3.hpp"
 
 namespace p3a {
 
@@ -251,6 +252,36 @@ auto operator*(symmetric3x3<A> const& a, vector3<B> const& b)
 }
 
 template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(symmetric3x3<A> const& a, symmetric3x3<B> const& b)
+{
+  using C = decltype(a.xx() * b.xx());
+  return symmetric3x3<C>(
+    a.xx() * b.xx() + a.xy() * b.xy() + a.xz() * b.xz(),
+    a.xx() * b.xy() + a.xy() * b.yy() + a.xz() * b.yz(),
+    a.xx() * b.xz() + a.xy() * b.yz() + a.xz() * b.zz(),
+    a.xy() * b.xy() + a.yy() * b.yy() + a.yz() * b.yz(),
+    a.xy() * b.xz() + a.yy() * b.yz() + a.yz() * b.zz(),
+    a.xz() * b.xz() + a.yz() * b.yz() + a.zz() * b.zz()
+  );
+}
+
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+symmetric3x3<T> isotropic_part(symmetric3x3<T> const& a)
+{
+  auto const d = trace(a) / T(3.);
+  return symmetric3x3<T>(d, T(0.0), T(0.0), d, T(0.0), d);
+}
+
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+symmetric3x3<T> deviatoric_part(symmetric3x3<T> const& a)
+{
+  return a - isotropic_part(a);
+}
+
+template <class A, class B>
 P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 auto frobenius_inner_product(
     symmetric3x3<A> const& a, symmetric3x3<B> const& b)
@@ -262,6 +293,38 @@ auto frobenius_inner_product(
        a.yy() * b.yy() +
        2 * a.yz() * b.yz() +
        a.zz() * b.zz();
+}
+
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+T determinant(symmetric3x3<T> const& a)
+{
+  return
+    a.xx() * a.yy() * a.zz() -
+    a.xx() * a.yz() * a.yz() -
+    a.xy() * a.xy() * a.zz() +
+    T(2.0) * a.xy() * a.xz() * a.yz() -
+    a.xz() * a.xz() * a.yy();
+}
+
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto inverse(symmetric3x3<T> const& a)
+{
+  auto const det = determinant(a);
+  T constexpr epsilon = std::numeric_limits<T>::epsilon();
+  if (std::abs(det) <= epsilon)
+  {
+    throw std::logic_error("non-invertible matrix");
+  }
+  auto const xx = +(a.yy() * a.zz() - a.yz() * a.yz());
+  auto const xy = -(a.xy() * a.zz() - a.yz() * a.xz());
+  auto const xz = +(a.xy() * a.yz() - a.yy() * a.xz());
+  auto const yy = +(a.xx() * a.zz() - a.xz() * a.xz());
+  auto const yz = -(a.xx() * a.yz() - a.xy() * a.xz());
+  auto const zz = +(a.xx() * a.yy() - a.xy() * a.xy());
+  using result_type = std::remove_const_t<decltype(xx)>;
+  return symmetric3x3<result_type>(xx, xy, xz, yy, yz, zz) / det;
 }
 
 template <class T>

--- a/p3a_unit_tests.cpp
+++ b/p3a_unit_tests.cpp
@@ -2467,3 +2467,80 @@ TEST(polar_decomp, simple_shear){
   EXPECT_FLOAT_EQ(zero, R.zy()) << "R.zy()";
   EXPECT_FLOAT_EQ(one, R.zz()) << "R.zz()";
 }
+
+
+TEST(symmetric3x3, isotropic_part){
+  using T = double;
+  T const zero = T(0.);
+  T const one = T(1.);
+  T const two = T(2.);
+  T const three = T(3.);
+  T const six = T(6.);
+  symmetric3x3<T> a{one, zero, zero, one, zero, one};
+  symmetric3x3<T> b;
+  b = isotropic_part(a);
+  EXPECT_FLOAT_EQ(trace(b), trace(a));
+  EXPECT_FLOAT_EQ(b.xx(), one);
+  EXPECT_FLOAT_EQ(b.yy(), one);
+  EXPECT_FLOAT_EQ(b.zz(), one);
+  a.yy() = two;
+  a.zz() = three;
+  b = isotropic_part(a);
+  EXPECT_FLOAT_EQ(trace(b), trace(a));
+  EXPECT_FLOAT_EQ(b.xx(), six / three);
+  EXPECT_FLOAT_EQ(b.yy(), b.xx());
+  EXPECT_FLOAT_EQ(b.zz(), b.xx());
+}
+
+TEST(symmetric3x3, deviatoric_part){
+  using T = double;
+  T const zero = T(0.);
+  T const one = T(1.);
+  T const two = T(2.);
+  T const three = T(3.);
+  T const six = T(6.);
+  symmetric3x3<T> a{one, one, one, one, one, one};
+  symmetric3x3<T> b;
+  b = deviatoric_part(a);
+  EXPECT_FLOAT_EQ(trace(b), zero);
+  EXPECT_FLOAT_EQ(b.xx(), zero);
+  EXPECT_FLOAT_EQ(b.yy(), zero);
+  EXPECT_FLOAT_EQ(b.zz(), zero);
+  EXPECT_FLOAT_EQ(b.xy(), one);
+  EXPECT_FLOAT_EQ(b.xz(), one);
+  EXPECT_FLOAT_EQ(b.yz(), one);
+  a.yy() = two;
+  a.zz() = three;
+  b = deviatoric_part(a);
+  EXPECT_FLOAT_EQ(trace(b), zero);
+  EXPECT_FLOAT_EQ(b.xx(), one - six / three);
+  EXPECT_FLOAT_EQ(b.yy(), two - six / three);
+  EXPECT_FLOAT_EQ(b.zz(), three - six / three);
+}
+
+TEST(symmetric3x3, inverse_diag){
+  using T = double;
+  T const zero = T(0.);
+  T const one = T(1.);
+  T const two = T(2.);
+  symmetric3x3<T> a{two, zero, zero, two, zero, two};
+  auto ai = inverse(a);
+  EXPECT_FLOAT_EQ(ai.xx(), one / two);
+  EXPECT_FLOAT_EQ(ai.yy(), one / two);
+  EXPECT_FLOAT_EQ(ai.zz(), one / two);
+  EXPECT_FLOAT_EQ(ai.xy(), zero);
+  EXPECT_FLOAT_EQ(ai.xz(), zero);
+  EXPECT_FLOAT_EQ(ai.yz(), zero);
+}
+
+TEST(symmetric3x3, inverse){
+  using T = double;
+  symmetric3x3<T> a{1., .5, .1, 2., .2, 3.};
+  auto ai = inverse(a);
+  EXPECT_FLOAT_EQ(ai.xx(), 1.143953934740883);
+  EXPECT_FLOAT_EQ(ai.yy(), 0.5738963531669865);
+  EXPECT_FLOAT_EQ(ai.zz(), 0.33589251439539347);
+  EXPECT_FLOAT_EQ(ai.xy(), -0.2840690978886756);
+  EXPECT_FLOAT_EQ(ai.xz(), -0.019193857965451054);
+  EXPECT_FLOAT_EQ(ai.yz(), -0.028790786948176588);
+}


### PR DESCRIPTION
tests added: yes
closes: #6

@ibaned - `symmetric3x3::inverse` throws an error if `determinant(a) <= 0` and needs to be changed to an error handling system appropriate for GPU.  Does p3a have a standard GPU error handling policy?